### PR TITLE
Test event log completeness

### DIFF
--- a/tests/aem_hw.pm
+++ b/tests/aem_hw.pm
@@ -141,7 +141,28 @@ sub run {
         wait_for_startup();
 
         # collect event log dump
-        assert_script_run('anti-evil-maid-dump-evt-log');
+        assert_script_run('anti-evil-maid-dump-evt-log > /tmp/aem_event.log');
+
+        # check if log has all expected entries
+        if ($drtm_kind eq 'skinit') {
+            assert_script_run('grep "SKINIT" /tmp/aem_event.log');
+            assert_script_run('grep "DLME entry offset" /tmp/aem_event.log');
+            assert_script_run('grep "DLME$" /tmp/aem_event.log');
+        } elsif ($drtm_kind eq 'txt') {
+            # TODO: TXT uses event types instead of names
+        } else {
+            die "Unhandled DRTM kind run(): '$drtm_kind'!";
+        }
+        assert_script_run('grep "Xen\'s command line" /tmp/aem_event.log');
+        assert_script_run('grep "MB module string" /tmp/aem_event.log');
+        assert_script_run('grep "MB module$" /tmp/aem_event.log');
+
+        # check if PCRs match
+        my $pcrs_str = script_output('ls /sys/class/tpm/tpm0/pcr-sha*/1[78] -1');
+        my @pcrs = split ' ', $pcrs_str;
+        for my $pcr (@pcrs) {
+            assert_script_run("grep -wi \$(cat $pcr) /tmp/aem_event.log");
+        }
     }
 }
 

--- a/tests/aem_hw.pm
+++ b/tests/aem_hw.pm
@@ -19,6 +19,7 @@ use base "installedtest";
 use strict;
 use testapi;
 use serial_terminal;
+use networking;
 use utils qw(assert_serial);
 use Data::Dumper;
 
@@ -138,10 +139,16 @@ sub run {
         handle_aem_startup();
         handle_luks_pass();
         assert_screen "aem-secret.txt-sealed", timeout => 60;
-        wait_for_startup();
+
+        # use full init_gui_session - netvm must be running to upload logs
+        $self->init_gui_session;
+        select_root_console();
 
         # collect event log dump
         assert_script_run('anti-evil-maid-dump-evt-log > /tmp/aem_event.log');
+        # store event log in case manual inspection will be needed
+        curl_via_netvm;
+        upload_logs('/tmp/aem_event.log', failok => 1);
 
         # check if log has all expected entries
         if ($drtm_kind eq 'skinit') {


### PR DESCRIPTION
Just AMD part for now, tested on both TPM1.2 and 2.0. The code was added to `aem-second-run`, but earlier stages require changes from `t630_legacy` (which doesn't support legacy yet, but fixes some of the issues under UEFI).