### PR TITLE
tests/aem_hw.pm: update RPM key name

### DIFF
--- a/tests/aem_hw.pm
+++ b/tests/aem_hw.pm
@@ -487,7 +487,7 @@ sub setup_acm {
 
 sub add_aem_repository {
     my $base_url = get_var('PACKAGES_BASE_URL');
-    my $key_file = "RPM-GPG-KEY-aem";
+    my $key_file = "RPM-GPG-KEY-tb-aem";
     my $key_url = "${base_url}/${key_file}";
     my $repo_definition = "[aem]\\nname = Anti Evil Maid based on TrenchBoot\\nbaseurl = $base_url\\ngpgcheck = 1\\ngpgkey = $key_url\\nenabled=1";
 


### PR DESCRIPTION
It was always like the new one for release packages. The file was incorrectly named RPM-GPG-KEY-aem in RC2, and was left like that until now.